### PR TITLE
Fix: check for URLs including trailing slash

### DIFF
--- a/dorpsgek/events/commit_comment.py
+++ b/dorpsgek/events/commit_comment.py
@@ -10,7 +10,7 @@ async def commit_comment(event, github_api):
         return
 
     commits_url = event.data["repository"]["commits_url"]
-    assert commits_url.startswith("https://api.github.com")
+    assert commits_url.startswith("https://api.github.com/")
     commits_url = commits_url[len("https://api.github.com"):]
     assert commits_url.endswith("{/sha}")
     commits_url = commits_url.replace("{/sha}", "/" + event.data["comment"]["commit_id"])

--- a/dorpsgek/events/pull_request.py
+++ b/dorpsgek/events/pull_request.py
@@ -38,7 +38,7 @@ async def issue_comment(event, github_api):
     # To not assume Pull Request are always against 'master',
     # we take an extra roundtrip to find the base branch
     pull_request_url = event.data["issue"]["pull_request"]["url"]
-    assert pull_request_url.startswith("https://api.github.com")
+    assert pull_request_url.startswith("https://api.github.com/")
     pull_request_url = pull_request_url[len("https://api.github.com"):]
     response = await github_api.getitem(pull_request_url)
 


### PR DESCRIPTION
Although this is not really relevant in our case, LGTM rightfully
indicates that these 'startswith' can still have URLs like
'https://api.github.com.fake.domain', and validate. We of course
not as much use the validation to check if it really comes from
github.com, merely to ensure that the next statement is valid.
Nevertheless, it is a sane change to make.