### PR TITLE
Fix: [Actions] Dorpsgek only runs on production, not on staging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,8 @@ jobs:
         name: ${{ steps.vars.outputs.name }}
         tag: ${{ steps.vars.outputs.tag }}
 
-    - if: steps.vars.outputs.dry-run == 'false'
+    # Dorpsgek only runs on production, not on staging.
+    - if: steps.vars.outputs.dry-run == 'false' && steps.vars.outputs.environment == 'production'
       name: Trigger deployment
       uses: openttd/actions/deployments-create@v1
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY requirements.txt \
         dorpsgek.ini \
         /code/
 COPY dorpsgek /code/dorpsgek
+# Needed for Sentry to know what version we are running
+RUN echo "${BUILD_VERSION}" > /code/.version
 
 RUN pip install -r requirements.txt
 

--- a/dorpsgek/__main__.py
+++ b/dorpsgek/__main__.py
@@ -33,10 +33,19 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 @click.option("--github-app-secret", help="GitHub App Secret", required=True)
 @click.option("--port", help="Port of the server", default=80, show_default=True)
 @click.option("--sentry-dsn", help="Sentry DSN")
+@click.option(
+    "--sentry-environment", help="Environment we are running in (for Sentry)", default="development",
+)
 def main(
-    github_app_id, github_app_private_key, github_app_private_key_file, github_app_secret, port, sentry_dsn,
+    github_app_id,
+    github_app_private_key,
+    github_app_private_key_file,
+    github_app_secret,
+    port,
+    sentry_dsn,
+    sentry_environment,
 ):
-    sentry.setup_sentry(sentry_dsn)
+    sentry.setup_sentry(sentry_dsn, sentry_environment)
 
     logging.basicConfig(
         format="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO,

--- a/dorpsgek/helpers/sentry.py
+++ b/dorpsgek/helpers/sentry.py
@@ -1,19 +1,16 @@
 import logging
-import os
 import sentry_sdk
 
 log = logging.getLogger(__name__)
 
 
-def setup_sentry(sentry_dsn):
+def setup_sentry(sentry_dsn, environment):
     if not sentry_dsn:
         return
 
     # Release is expected to be in the file '.version'
     with open(".version") as f:
         release = f.readline().strip()
-    # HOSTNAME is expected to be in form of 'environment-...'
-    environment = os.getenv("HOSTNAME", "dev").split("-")[0]
 
     sentry_sdk.init(sentry_dsn, release=release, environment=environment)
     log.info(


### PR DESCRIPTION
This is because otherwise the staging and production version will
keep battling for their IRC nickname. This could be changed in
the future, but currently it simply doesn't work.