### PR TITLE
Render http://... and https:// as <a> in the weblogs.

### DIFF
--- a/plugins/WebLogsS3/render_channel.py
+++ b/plugins/WebLogsS3/render_channel.py
@@ -38,5 +38,5 @@ def render_channel(base_url, channel):
             result += "<li>"
         result += "</ul>"
 
-    result += "</body>\n"
+    result += "</body>\n</html>\n"
     return result

--- a/plugins/WebLogsS3/render_day.py
+++ b/plugins/WebLogsS3/render_day.py
@@ -132,5 +132,5 @@ def render_day(base_url, channel, date, has_prev_day=None):
                 result += f'<div><a class="anchor" name="{anchor}" href="#{anchor}">{time}</a>  '
                 result += f'<span class="{classname}">{text}</span></div>\n'
 
-    result += f"{next_day}</pre>\n</body>\n"
+    result += f"{next_day}</pre>\n</body>\n</html>\n"
     return result

--- a/plugins/WebLogsS3/render_day.py
+++ b/plugins/WebLogsS3/render_day.py
@@ -3,6 +3,7 @@ import glob
 import html
 import os
 import re
+import urllib.parse
 
 FIRST_LOGDATE = {}
 
@@ -104,6 +105,13 @@ def render_day(base_url, channel, date, has_prev_day=None):
 
                 text = html.escape(text)
                 anchor = f'{time.replace(":", "")}-{lineno}'
+
+                # Detect links
+                text = re.sub(
+                    r"\bhttps?:\/\/([^\s()\.,]|\([^)\s]*\)|[\.,]\S)+",
+                    lambda m: f'<a href="{urllib.parse.quote(html.unescape(m.group()), safe="/:")}">{m.group()}</a>',
+                    text,
+                )
 
                 classname = "text"
                 if text.startswith("***"):

--- a/plugins/WebLogsS3/render_list.py
+++ b/plugins/WebLogsS3/render_list.py
@@ -27,5 +27,5 @@ def render_list(base_url):
             result += "<li>"
         result += "</ul>"
 
-    result += "</body>\n"
+    result += "</body>\n</html>\n"
     return result

--- a/plugins/WebLogsS3/render_month.py
+++ b/plugins/WebLogsS3/render_month.py
@@ -43,5 +43,5 @@ def render_month(base_url, channel, date):
             result += "</li>"
         result += "</ul>"
 
-    result += "</body>\n"
+    result += "</body>\n</html>\n"
     return result

--- a/plugins/WebLogsS3/render_year.py
+++ b/plugins/WebLogsS3/render_year.py
@@ -42,5 +42,5 @@ def render_year(base_url, channel, date):
             result += "</li>"
         result += "</ul>"
 
-    result += "</body>\n"
+    result += "</body>\n</html>\n"
     return result


### PR DESCRIPTION
With this text starting with http:// or https:// is rendered as link up to the first space.

The detection is inserted after the html escaping. The linktext remains html-escaped, the url is html-unescaped and then url-quoted...

I tested this out of context, so I hope there is some staging :)