### PR TITLE
Fix: use the default branch of a repository to load .dorpsgek.yml

### DIFF
--- a/plugins/GitHub/events/push.py
+++ b/plugins/GitHub/events/push.py
@@ -80,5 +80,4 @@ async def push(event, github_api):
         "commits": commits,
     }
 
-    ref = event.data["head_commit"]["id"]
-    await protocols.dispatch(github_api, repository_name, "push", payload, ref=ref, filter_func=filter_func)
+    await protocols.dispatch(github_api, repository_name, "push", payload, filter_func=filter_func)

--- a/plugins/GitHub/helpers/dorpsgek.py
+++ b/plugins/GitHub/helpers/dorpsgek.py
@@ -28,7 +28,7 @@ async def get_dorpsgek_yml(github_api, repository):
     return base64.b64decode(response["content"])
 
 
-async def get_notification_protocols(github_api, repository_name, ref, type):
+async def get_notification_protocols(github_api, repository_name, type):
     protocols = defaultdict(list)
     # Always inform the #dorpsgek IRC channel about everything
     protocols["irc"].append("dorpsgek")
@@ -36,7 +36,7 @@ async def get_notification_protocols(github_api, repository_name, ref, type):
     try:
         raw_yml = await get_dorpsgek_yml(github_api, repository_name)
     except Exception:
-        log.exception("Couldn't parse .dorpsgek.yml in %s at ref %s", repository_name, ref)
+        log.exception("Couldn't parse .dorpsgek.yml in %s", repository_name)
         return protocols
 
     if not raw_yml:

--- a/plugins/GitHub/helpers/dorpsgek.py
+++ b/plugins/GitHub/helpers/dorpsgek.py
@@ -13,9 +13,9 @@ log = logging.getLogger(__name__)
 async def get_dorpsgek_yml(github_api, repository):
     try:
         oauth_token = await get_oauth_token(repository)
-        # Always use .dorpsgek.yml from master
+        # Always use .dorpsgek.yml from the default branch
         response = await github_api.getitem(
-            f"/repos/{repository}/contents/.dorpsgek.yml?ref=master",
+            f"/repos/{repository}/contents/.dorpsgek.yml",
             oauth_token=oauth_token,
         )
     except gidgethub.BadRequest as err:

--- a/plugins/GitHub/helpers/protocols.py
+++ b/plugins/GitHub/helpers/protocols.py
@@ -8,8 +8,8 @@ log = logging.getLogger(__name__)
 _protocols = defaultdict(dict)
 
 
-async def dispatch(github_api, repository_name, type, payload, ref="master", filter_func=None):
-    protocols = await get_notification_protocols(github_api, repository_name, ref, type)
+async def dispatch(github_api, repository_name, type, payload, filter_func=None):
+    protocols = await get_notification_protocols(github_api, repository_name, type)
 
     # If a filter function is set, and it returns False, don't broadcast
     # this notification


### PR DESCRIPTION
It used to force `master`, but given we are converting to `main` and GitHub allows you to use any name, don't force it to `master` anymore.

Instead, use the default branch, which is fetched when you don't mention any `ref` value.