### PR TITLE
Remove: git.io closed its doors; no longer try to use their service

### DIFF
--- a/plugins/GitHub/helpers/url.py
+++ b/plugins/GitHub/helpers/url.py
@@ -1,13 +1,2 @@
-import aiohttp
-
-
 async def shorten(url):
-    data = aiohttp.FormData()
-    data.add_field("url", url)
-
-    async with aiohttp.ClientSession() as session:
-        async with session.post("https://git.io", data=data) as resp:
-            if resp.status == 201 and "Location" in resp.headers:
-                return resp.headers["Location"]
-
     return url


### PR DESCRIPTION
There also really isn't an alternative, so we will have to make do
with the very long URLs.