### PR TITLE
Fix ddde6d71: .dorpsgek.yml except-by are regular expressions

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -6,6 +6,6 @@ notifications:
 
   pull-request:
     except-by:
-    - dependabot[bot]
+    - dependabot\[bot\]
   issue:
   tag-created:


### PR DESCRIPTION
So the [] did something else. Escaping them solves the issue.