### PR TITLE
Fix: links with fragments were escaped incorrectly.

### DIFF
--- a/plugins/WebLogsS3/render_day.py
+++ b/plugins/WebLogsS3/render_day.py
@@ -109,7 +109,7 @@ def render_day(base_url, channel, date, has_prev_day=None):
                 # Detect links
                 text = re.sub(
                     r"\bhttps?:\/\/([^\s()\.,]|\([^)\s]*\)|[\.,]\S)+",
-                    lambda m: f'<a href="{urllib.parse.quote(html.unescape(m.group()), safe="/:")}">{m.group()}</a>',
+                    lambda m: f'<a href="{urllib.parse.quote(html.unescape(m.group()), safe="/:#")}">{m.group()}</a>',
                     text,
                 )
 


### PR DESCRIPTION
For links containing fragments (#) the hash was escaped, which made it part of the path.

Actual:
[https://github.com/OpenTTD/OpenTTD/pull/9961%23pullrequestreview-1064391518](https://github.com/OpenTTD/OpenTTD/pull/9961%23pullrequestreview-1064391518)

Expected:
[https://github.com/OpenTTD/OpenTTD/pull/9961#pullrequestreview-1064391518](https://github.com/OpenTTD/OpenTTD/pull/9961%23pullrequestreview-1064391518)
