### PR TITLE
Feature: option to announce GitHub events on Discord

### DIFF
--- a/dorpsgek/__main__.py
+++ b/dorpsgek/__main__.py
@@ -29,6 +29,8 @@ from openttd_helpers.sentry_helper import click_sentry
     multiple=True,
     default=["dorpsgek-test"],
 )
+@click.option("--discord-webhook-url", help="URL to the Discord webhook")
+@click.option("--discord-unfiltered-webhook-url", help="URL to the Discord webhook that receives all events")
 @click.option("--port", help="Port of the server", default=80, show_default=True)
 def main(
     github_app_id,
@@ -41,6 +43,8 @@ def main(
     addressed_by,
     web_logs_url,
     channel,
+    discord_webhook_url,
+    discord_unfiltered_webhook_url,
     port,
 ):
     if github_app_private_key_file:
@@ -59,6 +63,8 @@ def main(
         fp.write(f"GITHUB_APP_SECRET = {github_app_secret!r}\n")
         fp.write(f"GITHUB_APP_ID = {github_app_id!r}\n")
         fp.write(f"GITHUB_APP_PRIVATE_KEY = {github_private_key!r}\n")
+        fp.write(f"DISCORD_WEBHOOK_URL = {discord_webhook_url!r}\n")
+        fp.write(f"DISCORD_UNFILTERED_WEBHOOK_URL = {discord_unfiltered_webhook_url!r}\n")
 
     with open("plugins/WebLogsS3/settings.py", "w") as fp:
         public_channels = [f"#{c.split(',')[0]}" for c in set(channel) if c.endswith(",public")]

--- a/plugins/GitHub/events/commit_comment.py
+++ b/plugins/GitHub/events/commit_comment.py
@@ -20,6 +20,7 @@ async def commit_comment(event, github_api):
         "repository_name": repository_name,
         "url": event.data["comment"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
         "message": response["commit"]["message"].split("\n")[0],
     }
 

--- a/plugins/GitHub/events/discussion.py
+++ b/plugins/GitHub/events/discussion.py
@@ -13,6 +13,7 @@ async def discussion(event, github_api):
         "title": event.data["discussion"]["title"],
         "url": event.data["discussion"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
     }
 
     if payload["action"] not in ("created",):
@@ -35,6 +36,7 @@ async def discussion_comment(event, github_api):
         "title": event.data["discussion"]["title"],
         "url": event.data["discussion"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
     }
 
     await protocols.dispatch(github_api, repository_name, "discussion", payload)

--- a/plugins/GitHub/events/issue.py
+++ b/plugins/GitHub/events/issue.py
@@ -53,6 +53,8 @@ async def issues(event, github_api):
         "title": event.data["issue"]["title"],
         "url": event.data["issue"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
+        "reason": event.data["issue"]["state_reason"],
     }
 
     if payload["action"] not in ("opened", "closed", "reopened"):
@@ -78,6 +80,8 @@ async def issue_comment(event, github_api):
         "title": event.data["issue"]["title"],
         "url": event.data["issue"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
+        "reason": None,
     }
 
     await protocols.dispatch(github_api, repository_name, "issue", payload, filter_func=filter_func)

--- a/plugins/GitHub/events/pull_request.py
+++ b/plugins/GitHub/events/pull_request.py
@@ -40,6 +40,7 @@ async def pull_request(event, github_api):
         "title": event.data["pull_request"]["title"],
         "url": event.data["pull_request"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
         "author": event.data["pull_request"]["user"]["login"],
     }
 
@@ -64,6 +65,7 @@ async def issue_comment(event, github_api):
         "pull_id": event.data["issue"]["number"],
         "url": event.data["comment"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
         "title": event.data["issue"]["title"],
         "action": "comment",
         "author": event.data["issue"]["user"]["login"],
@@ -82,6 +84,7 @@ async def pull_request_review(event, github_api):
         "title": event.data["pull_request"]["title"],
         "url": event.data["review"]["html_url"],
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
         "action": event.data["action"],
         "author": event.data["pull_request"]["user"]["login"],
     }

--- a/plugins/GitHub/events/push.py
+++ b/plugins/GitHub/events/push.py
@@ -48,7 +48,6 @@ async def push(event, github_api):
     if event.data["created"] or event.data["deleted"]:
         return
 
-    branch = event.data["ref"]
     repository_name = event.data["repository"]["full_name"]
 
     commits = [
@@ -59,7 +58,6 @@ async def push(event, github_api):
         }
         for commit in event.data["commits"]
     ]
-    user = event.data["sender"]["login"]
 
     if len(event.data["commits"]) > 1:
         url = event.data["compare"]
@@ -67,14 +65,15 @@ async def push(event, github_api):
         url = event.data["commits"][0]["url"]
 
     # Only notify about pushes to heads; not to tags etc
+    branch = event.data["ref"]
     if not branch.startswith("refs/heads/"):
         return
-
     branch = branch[len("refs/heads/") :]
 
     payload = {
         "repository_name": repository_name,
-        "user": user,
+        "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
         "url": url,
         "branch": branch,
         "commits": commits,

--- a/plugins/GitHub/events/tag.py
+++ b/plugins/GitHub/events/tag.py
@@ -19,6 +19,7 @@ async def create(event, github_api):
     payload = {
         "repository_name": repository_name,
         "user": event.data["sender"]["login"],
+        "avatar_url": event.data["sender"]["avatar_url"],
         "url": url,
         "name": ref_name,
     }

--- a/plugins/GitHub/plugin.py
+++ b/plugins/GitHub/plugin.py
@@ -15,6 +15,7 @@ from .events import (  # noqa
 )
 from .patches import gidgethub  # noqa
 from .protocols import irc as irc_protocols  # noqa
+from .protocols import discord as discord_protocols  # noqa
 
 
 class GitHubCallback(httpserver.SupyHTTPServerCallback):

--- a/plugins/GitHub/protocols/discord.py
+++ b/plugins/GitHub/protocols/discord.py
@@ -1,0 +1,125 @@
+import aiohttp
+import logging
+
+from ..helpers import protocols
+
+log = logging.getLogger(__name__)
+
+
+async def _send_messages(hook_urls, user, avatar_url, message):
+    async with aiohttp.ClientSession() as session:
+        for hook_url in hook_urls:
+            resp = await session.post(
+                hook_url,
+                json={
+                    "content": message,
+                    "username": f"{user} (via GitHub)",
+                    "avatar_url": avatar_url,
+                    "allowed_mentions": {},
+                    "flags": 1 << 2,  # SUPPRESS_EMBEDS
+                },
+            )
+            if resp.status != 200:
+                log.error(f"Failed to send message to Discord: {resp.status}")
+
+
+@protocols.register("discord", "pull-request")
+async def pull_request(hook_urls, repository_name, url, user, avatar_url, action, pull_id, title, author):
+    message = f"**{repository_name}** - "
+
+    if action == "opened":
+        message += f":postbox: opened pull request: {url}\n> {title}"
+    elif action == "closed":
+        message += f":no_entry: closed pull request: {url}\n> {title}"
+    elif action == "merged":
+        message += f":rocket: merged pull request: {url}\n> {title}"
+    elif action == "synchronize":
+        message += f":mega: updated pull request: {url}\n> {title}"
+    elif action == "reopened":
+        message += f":mailbox_with_mail: reopened pull request: {url}\n> {title}"
+    elif action == "comment":
+        message += f":speech_balloon: commented on pull request: {url}\n> {title}"
+    elif action == "dismissed":
+        message += f":eyes: dismissed a review for pull request: {url}\n> {title}"
+    elif action == "approved":
+        message += f":thumbsup: approved pull request: {url}\n> {title}"
+    elif action == "changes_requested":
+        message += f":negative_squared_cross_mark: requested changes for pull request: {url}\n> {title}"
+    elif action == "commented":
+        message += f":speech_balloon: commented on pull request: {url}\n> {title}"
+    else:
+        return
+
+    await _send_messages(hook_urls, user, avatar_url, message)
+
+
+@protocols.register("discord", "push")
+async def push(hook_urls, repository_name, url, user, avatar_url, branch, commits):
+    if len(commits) == 1:
+        commit_text = "a commit"
+    else:
+        commit_text = f"{len(commits)} commits"
+
+    message = f"**{repository_name}** - :muscle: pushed {commit_text} to `{branch}`: {url}\n> "
+    message += "\n> ".join([f"{commit['message']} (by {commit['author']})" for commit in commits])
+
+    await _send_messages(hook_urls, user, avatar_url, message)
+
+
+@protocols.register("discord", "issue")
+async def issue(hook_urls, repository_name, url, user, avatar_url, action, issue_id, title, reason):
+    message = f"**{repository_name}** - "
+
+    if action == "opened":
+        message += f":beetle: opened issue: {url}\n> {title}"
+    elif action == "reopened":
+        message += f":scream_cat: reopened issue: {url}\n> {title}"
+    elif action == "closed":
+        if reason == "completed":
+            message += f":sunglasses: closed issue: {url}\n> {title}"
+        else:
+            message += f":triumph: closed issue: {url}\n> {title}"
+    elif action == "comment":
+        message += f":speech_balloon: commented on issue: {url}\n> {title}"
+    else:
+        return
+
+    await _send_messages(hook_urls, user, avatar_url, message)
+
+
+@protocols.register("discord", "discussion")
+async def discussion(hook_urls, repository_name, url, user, avatar_url, action, discussion_id, title):
+    message = f"**{repository_name}** - "
+
+    if action == "created":
+        message += f":speaking_head: started discussion: {url}\n> {title}"
+    elif action == "comment":
+        message += f":speech_balloon: commented on discussion: {url}\n> {title}"
+    else:
+        return
+
+    await _send_messages(hook_urls, user, avatar_url, message)
+
+
+@protocols.register("discord", "commit-comment")
+async def commit_comment(hook_urls, repository_name, url, user, avatar_url, message):
+    message = f"**{repository_name}** - "
+    message += f":open_mouth: left a comment on commit: {url}\n> {message}"
+
+    await _send_messages(hook_urls, user, avatar_url, message)
+
+
+@protocols.register("discord", "branch-created")
+async def ref_branch_created(hook_urls, repository_name, url, user, avatar_url, name):
+    message = f"**{repository_name}** - "
+    message += f":cow: created a new branch `{name}`: {url}"
+
+    await _send_messages(hook_urls, user, avatar_url, message)
+
+
+@protocols.register("discord", "tag-created")
+async def ref_tag_created(hook_urls, repository_name, url, user, avatar_url, name):
+    message = f"**{repository_name}** - "
+    message += f":tada: created a new tag `{name}`: {url}"
+
+    await _send_messages(hook_urls, user, avatar_url, message)

--- a/plugins/GitHub/protocols/irc.py
+++ b/plugins/GitHub/protocols/irc.py
@@ -14,7 +14,7 @@ def _send_messages(channels, messages):
 
 
 @protocols.register("irc", "pull-request")
-async def pull_request(channels, repository_name, url, user, action, pull_id, title, author):
+async def pull_request(channels, repository_name, url, user, avatar_url, action, pull_id, title, author):
     if action == "opened":
         message = f"{user} opened pull request #{pull_id}: {title}"
     elif action == "closed":
@@ -43,7 +43,7 @@ async def pull_request(channels, repository_name, url, user, action, pull_id, ti
 
 
 @protocols.register("irc", "push")
-async def push(channels, repository_name, url, user, branch, commits):
+async def push(channels, repository_name, url, user, avatar_url, branch, commits):
     commit_count = len(commits)
 
     shortened_url = await shorten(url)
@@ -55,7 +55,7 @@ async def push(channels, repository_name, url, user, branch, commits):
 
 
 @protocols.register("irc", "issue")
-async def issue(channels, repository_name, url, user, action, issue_id, title):
+async def issue(channels, repository_name, url, user, avatar_url, action, issue_id, title, reason):
     if action == "opened":
         message = f"{user} opened issue #{issue_id}: {title}"
     elif action == "reopened":
@@ -72,7 +72,7 @@ async def issue(channels, repository_name, url, user, action, issue_id, title):
 
 
 @protocols.register("irc", "discussion")
-async def discussion(channels, repository_name, url, user, action, discussion_id, title):
+async def discussion(channels, repository_name, url, user, avatar_url, action, discussion_id, title):
     if action == "created":
         message = f"{user} started discussion #{discussion_id}: {title}"
     elif action == "comment":
@@ -85,7 +85,7 @@ async def discussion(channels, repository_name, url, user, action, discussion_id
 
 
 @protocols.register("irc", "commit-comment")
-async def commit_comment(channels, repository_name, url, user, message):
+async def commit_comment(channels, repository_name, url, user, avatar_url, message):
     message = f"{user} left a comment on commit: {message}"
 
     shortened_url = await shorten(url)
@@ -93,7 +93,7 @@ async def commit_comment(channels, repository_name, url, user, message):
 
 
 @protocols.register("irc", "branch-created")
-async def ref_branch_created(channels, repository_name, url, user, name):
+async def ref_branch_created(channels, repository_name, url, user, avatar_url, name):
     shortened_url = await shorten(url)
     _send_messages(
         channels,
@@ -102,7 +102,7 @@ async def ref_branch_created(channels, repository_name, url, user, name):
 
 
 @protocols.register("irc", "tag-created")
-async def ref_tag_created(channels, repository_name, url, user, name):
+async def ref_tag_created(channels, repository_name, url, user, avatar_url, name):
     shortened_url = await shorten(url)
     _send_messages(
         channels,


### PR DESCRIPTION
For now it is a global setting, and not a per-repository setting.
This is mostly as for Discord we use webhooks; if we would add
that to the .dorpsgek.yml, it would mean anyone can talk to that
channel.