### PR TITLE
Change: use embeds for Discord messages, so we can link text

### DIFF
--- a/plugins/GitHub/protocols/discord.py
+++ b/plugins/GitHub/protocols/discord.py
@@ -12,14 +12,20 @@ async def _send_messages(hook_urls, user, avatar_url, message):
             resp = await session.post(
                 hook_url,
                 json={
-                    "content": message,
+                    "embeds": [
+                        {
+                            "description": message,
+                            "color": 0xFD7605,
+                        }
+                    ],
                     "username": f"{user} (via GitHub)",
                     "avatar_url": avatar_url,
-                    "allowed_mentions": {},
-                    "flags": 1 << 2,  # SUPPRESS_EMBEDS
+                    "allowed_mentions": {
+                        "parse": [],
+                    },
                 },
             )
-            if resp.status != 200:
+            if resp.status not in (200, 204):
                 log.error(f"Failed to send message to Discord: {resp.status}")
 
 
@@ -28,25 +34,25 @@ async def pull_request(hook_urls, repository_name, url, user, avatar_url, action
     message = f"**{repository_name}** - "
 
     if action == "opened":
-        message += f":postbox: opened pull request: {url}\n> {title}"
+        message += f":postbox: opened pull request [#{pull_id}]({url})\n> {title}"
     elif action == "closed":
-        message += f":no_entry: closed pull request: {url}\n> {title}"
+        message += f":no_entry: closed pull request [#{pull_id}]({url})\n> {title}"
     elif action == "merged":
-        message += f":rocket: merged pull request: {url}\n> {title}"
+        message += f":rocket: merged pull request [#{pull_id}]({url})\n> {title}"
     elif action == "synchronize":
-        message += f":mega: updated pull request: {url}\n> {title}"
+        message += f":mega: updated pull request [#{pull_id}]({url})\n> {title}"
     elif action == "reopened":
-        message += f":mailbox_with_mail: reopened pull request: {url}\n> {title}"
+        message += f":mailbox_with_mail: reopened pull request [#{pull_id}]({url})\n> {title}"
     elif action == "comment":
-        message += f":speech_balloon: commented on pull request: {url}\n> {title}"
+        message += f":speech_balloon: commented on pull request [#{pull_id}]({url})\n> {title}"
     elif action == "dismissed":
-        message += f":eyes: dismissed a review for pull request: {url}\n> {title}"
+        message += f":eyes: dismissed a review for pull request [#{pull_id}]({url})\n> {title}"
     elif action == "approved":
-        message += f":thumbsup: approved pull request: {url}\n> {title}"
+        message += f":thumbsup: approved pull request [#{pull_id}]({url})\n> {title}"
     elif action == "changes_requested":
-        message += f":negative_squared_cross_mark: requested changes for pull request: {url}\n> {title}"
+        message += f":negative_squared_cross_mark: requested changes for pull request [#{pull_id}]({url})\n> {title}"
     elif action == "commented":
-        message += f":speech_balloon: commented on pull request: {url}\n> {title}"
+        message += f":speech_balloon: commented on pull request [#{pull_id}]({url})\n> {title}"
     else:
         return
 
@@ -60,7 +66,7 @@ async def push(hook_urls, repository_name, url, user, avatar_url, branch, commit
     else:
         commit_text = f"{len(commits)} commits"
 
-    message = f"**{repository_name}** - :muscle: pushed {commit_text} to `{branch}`: {url}\n> "
+    message = f"**{repository_name}** - :muscle: pushed [{commit_text}]({url}) to `{branch}`\n> "
     message += "\n> ".join([f"{commit['message']} (by {commit['author']})" for commit in commits])
 
     await _send_messages(hook_urls, user, avatar_url, message)
@@ -71,16 +77,16 @@ async def issue(hook_urls, repository_name, url, user, avatar_url, action, issue
     message = f"**{repository_name}** - "
 
     if action == "opened":
-        message += f":beetle: opened issue: {url}\n> {title}"
+        message += f":beetle: opened issue [#{issue_id}]({url})\n> {title}"
     elif action == "reopened":
-        message += f":scream_cat: reopened issue: {url}\n> {title}"
+        message += f":scream_cat: reopened issue [#{issue_id}]({url})\n> {title}"
     elif action == "closed":
         if reason == "completed":
-            message += f":sunglasses: closed issue: {url}\n> {title}"
+            message += f":sunglasses: closed issue [#{issue_id}]({url})\n> {title}"
         else:
-            message += f":triumph: closed issue: {url}\n> {title}"
+            message += f":triumph: closed issue [#{issue_id}]({url})\n> {title}"
     elif action == "comment":
-        message += f":speech_balloon: commented on issue: {url}\n> {title}"
+        message += f":speech_balloon: commented on issue [#{issue_id}]({url})\n> {title}"
     else:
         return
 
@@ -92,9 +98,9 @@ async def discussion(hook_urls, repository_name, url, user, avatar_url, action, 
     message = f"**{repository_name}** - "
 
     if action == "created":
-        message += f":speaking_head: started discussion: {url}\n> {title}"
+        message += f":speaking_head: started discussion [#{discussion_id}]({url})\n> {title}"
     elif action == "comment":
-        message += f":speech_balloon: commented on discussion: {url}\n> {title}"
+        message += f":speech_balloon: commented on discussion [#{discussion_id}]({url})\n> {title}"
     else:
         return
 
@@ -112,7 +118,7 @@ async def commit_comment(hook_urls, repository_name, url, user, avatar_url, mess
 @protocols.register("discord", "branch-created")
 async def ref_branch_created(hook_urls, repository_name, url, user, avatar_url, name):
     message = f"**{repository_name}** - "
-    message += f":cow: created a new branch `{name}`: {url}"
+    message += f":cow: created a new branch [{name}]({url})"
 
     await _send_messages(hook_urls, user, avatar_url, message)
 
@@ -120,6 +126,6 @@ async def ref_branch_created(hook_urls, repository_name, url, user, avatar_url, 
 @protocols.register("discord", "tag-created")
 async def ref_tag_created(hook_urls, repository_name, url, user, avatar_url, name):
     message = f"**{repository_name}** - "
-    message += f":tada: created a new tag `{name}`: {url}"
+    message += f":tada: created a new tag [{name}]({url})"
 
     await _send_messages(hook_urls, user, avatar_url, message)


### PR DESCRIPTION
Only in embeds on Discord you can use `[a](link)`. This does come with
two benefits, and one drawback:

- We no longer have those very long links, which distract a lot
- Embeds have a different colour and stand out more from the rest of the text

Where the latter is a benefit and a drawback all at once.

Example:

![image](https://user-images.githubusercontent.com/1663690/187066630-b0094757-5750-4bdd-a95b-ba7e193754b3.png)
