### PR TITLE
Remove: "@seen" command from IRC

### DIFF
--- a/DorpsGek.conf
+++ b/DorpsGek.conf
@@ -799,7 +799,7 @@ supybot.nick.alternates: %s` %s_
 #
 # Default value:
 ###
-supybot.plugins: Aaa_HideCommands OpenTTD GitHub Channel Seen SimpleUser Math Topic Services ChannelLogger WebLogsS3
+supybot.plugins: Aaa_HideCommands OpenTTD GitHub Channel SimpleUser Math Topic Services ChannelLogger WebLogsS3
 
 ###
 # Determines whether this plugin is loaded by default.
@@ -980,35 +980,6 @@ supybot.plugins.Channel.public: True
 # Default value: 0
 ###
 supybot.plugins.Channel.rejoinDelay: 0
-
-###
-# Determines whether this plugin is loaded by default.
-###
-supybot.plugins.Seen: True
-
-###
-# The minimum non-wildcard characters required to perform a 'seen'
-# request. Of course, it only applies if there is a wildcard in the
-# request.
-#
-# Default value: 2
-###
-supybot.plugins.Seen.minimumNonWildcard: 2
-
-###
-# Determines whether this plugin is publicly visible.
-#
-# Default value: True
-###
-supybot.plugins.Seen.public: True
-
-###
-# Determines whether the last message will be displayed with @seen.
-# Useful for keeping messages from a channel private.
-#
-# Default value: True
-###
-supybot.plugins.Seen.showLastMessage: True
 
 ###
 # Determines whether this plugin is loaded by default.

--- a/plugins/Aaa_HideCommands/plugin.py
+++ b/plugins/Aaa_HideCommands/plugin.py
@@ -32,7 +32,6 @@ COMMAND_WHITELIST = {
         "topic",
     ),
     "WebLogsS3": ("logs",),
-    "Seen": ("seen",),
     "Channel": (
         "dehalfop",
         "deop",


### PR DESCRIPTION
It was rarely used, and a huge overhead backend-side. Besides that, it tends to glitch out causing missing records. In short: it is no longer worth the effort.