### PR TITLE
Add: option to set the URL to reach the GitHub API

### DIFF
--- a/dorpsgek/__main__.py
+++ b/dorpsgek/__main__.py
@@ -18,6 +18,13 @@ from openttd_helpers.sentry_helper import click_sentry
     type=click.Path(exists=True, dir_okay=False),
 )
 @click.option("--github-app-secret", help="GitHub App Secret")
+@click.option(
+    "--github-api-url",
+    help="GitHub API URL to use with GitHub App.",
+    default="https://api.github.com",
+    show_default=True,
+    metavar="URL",
+)
 @click.option("--irc-username", help="Nick to use on IRC", default="DorpsGek_dev")
 @click.option("--nickserv-username", help="Username as known by NickServ")
 @click.option("--nickserv-password", help="Password for --nickserv-username")
@@ -37,6 +44,7 @@ def main(
     github_app_private_key,
     github_app_private_key_file,
     github_app_secret,
+    github_api_url,
     irc_username,
     nickserv_username,
     nickserv_password,
@@ -63,6 +71,7 @@ def main(
         fp.write(f"GITHUB_APP_SECRET = {github_app_secret!r}\n")
         fp.write(f"GITHUB_APP_ID = {github_app_id!r}\n")
         fp.write(f"GITHUB_APP_PRIVATE_KEY = {github_private_key!r}\n")
+        fp.write(f"GITHUB_API_URL = {github_api_url!r}\n")
         fp.write(f"DISCORD_WEBHOOK_URL = {discord_webhook_url!r}\n")
         fp.write(f"DISCORD_UNFILTERED_WEBHOOK_URL = {discord_unfiltered_webhook_url!r}\n")
 

--- a/plugins/GitHub/helpers/github.py
+++ b/plugins/GitHub/helpers/github.py
@@ -24,7 +24,7 @@ _github_installations = {}
 class GitHubAPIContext:
     async def __aenter__(self):
         self._session = aiohttp.ClientSession()
-        return GitHubAPI(self._session, "DorpsGek/1.0")
+        return GitHubAPI(self._session, "DorpsGek/1.0", base_url=settings.GITHUB_API_URL)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._session.close()


### PR DESCRIPTION
As the GitHub API has no IPv6 support, it is needed to bounce this over an IPv6-enabled proxy. As such, this URL isn't always api.github.com for all deployments.