### PR TITLE
Fix: "Jump to today" target in weblogs

### DIFF
--- a/plugins/WebLogsS3/render_channel.py
+++ b/plugins/WebLogsS3/render_channel.py
@@ -27,7 +27,9 @@ def render_channel(base_url, channel):
         result += '<pre><span class="prev">(nothing was recorded for this channel)</span></pre>'
     else:
         result += "<ul>"
-        result += f'<li><a href="{base_url}/{channel}/{now.year}/{now.month}/{now.day}.html">Jump to today</a></li>'
+        result += "<li>"
+        result += f'<a href="{base_url}/{channel}/{now.year:04d}/{now.month:02d}/{now.day:02d}.html">Jump to today</a>'
+        result += "</li>"
         result += "</ul>"
 
         result += "<ul>"


### PR DESCRIPTION
"Jump to today" target is https://weblogs.openttd.org/openttd/2023/7/15.html while it should be https://weblogs.openttd.org/openttd/2023/07/15.html
Not a big issue since 07 and 7 are handled the same way, but all other links use the YYYY/MM/DD format in targets except "Jump to today".